### PR TITLE
Fix and optimise Docker image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ LABEL maintainer="joshua@froggi.es"
 
 RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pacman.conf
 RUN pacman-key --init
-RUN pacman -Sy --noconfirm archlinux-keyring
-RUN pacman -Syu --noconfirm clang meson glslang git mingw-w64 wine base base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms
+RUN pacman -Sy --needed --noconfirm archlinux-keyring
+RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM archlinux:base-devel-20210124.0.14185
 LABEL maintainer="joshua@froggi.es"
 
 RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pacman.conf
+RUN pacman-key --init
 RUN pacman -Sy --noconfirm archlinux-keyring
 RUN pacman -Syu --noconfirm clang meson glslang git mingw-w64 wine base base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Need to use an older version of Arch because of Pacman breakage...
-FROM archlinux:base-devel-20210124.0.14185
+FROM archlinux:base-devel
 
 LABEL maintainer="joshua@froggi.es"
 


### PR DESCRIPTION
First of the commits ("Initialise pacman keys") fixes the problem currently visible in building flows of dxvk and vkd3d-proton. As stated on [Docker page for archlinux images](https://hub.docker.com/_/archlinux), images don't come with pacman lsign key and the key needs to be created on Docker image creation.

Other two commits improves slightly image creation by using latest Docker image as a base image and skipping reinstalling packages that are already up-to-date. In my testing they improved image creation time by ~1 minute (reduction from ~3m to ~2m).

I successfully tested these changes on my forks of dxvk and vkd3d-proton.

Fell free to pull only the commits you like or reject all of them 🙂