### PR TITLE
Add workaround for git safe.directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pac
 RUN pacman-key --init
 RUN pacman -Sy --needed --noconfirm archlinux-keyring
 RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms
+RUN git config --system --add safe.directory /github/workspace
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
fix issue around git `safe.directory` on container side instead fixes on side of repository projects:
https://github.com/doitsujin/dxvk/pull/2722
https://github.com/HansKristian-Work/vkd3d-proton/commit/0c4df9b32cfa68ae7a84de412e5968785924d76b
https://github.com/jp7677/dxvk-nvapi/commit/3052a78a4d3e3c798286d759a7f3a8c03b3bd691