### PR TITLE
Add sdl2 and lib32_sdl2 for DXVK SDL2 WSI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="joshua@froggi.es"
 RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pacman.conf
 RUN pacman-key --init
 RUN pacman -Sy --needed --noconfirm archlinux-keyring
-RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base bash base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms glfw-x11
+RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base bash base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms glfw-x11 sdl2 lib32-sdl2
 RUN git config --system --add safe.directory /github/workspace
 
 # create a builduser, as we cant run makepkg as root


### PR DESCRIPTION
i actually don't know why this didn't cause a problem until today, but apparently *something* changed?
i think making dotnet install in the docker container rather than on the host is what broke the build and made sdl2 not be there(????), but im not sure, i was doing many unrelated changes to all my workflows, so it could be many things
either way it broke and i had to add these to the docker for the SDL2 WSI to build again