### PR TITLE
Add libunwind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="joshua@froggi.es"
 RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pacman.conf
 RUN pacman-key --init
 RUN pacman -Sy --needed --noconfirm archlinux-keyring
-RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base bash base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms glfw-x11
+RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine libunwind base bash base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms glfw-x11
 RUN git config --system --add safe.directory /github/workspace
 
 # create a builduser, as we cant run makepkg as root


### PR DESCRIPTION
This is a direct dependency of Wine, but unfortunately no longer in Wine's depends (not even transitively) since a recent dependency cleanup. Add libunwind here as a work around to allow Wine programs to run for consumers of this GitHub action.

See also https://bugs.archlinux.org/task/77413

I hope this can be dropped again in the future, but so far the Arch maintainers have chosen  to ignore this bug report :(