### PR TITLE
Fix building lib32-glfw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN passwd -d builduser
 RUN printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers 
 
 # clone, build, then install the lib32-glfw-x11 AUR package (there is no lib32 glfw in the standard Arch repositories)
-RUN sudo -u builduser bash -c 'export OLD_PWD=$PWD && cd ~ && git clone https://aur.archlinux.org/lib32-glfw.git lib32-glfw-x11 && cd lib32-glfw-x11 && makepkg -s --noconfirm && sudo pacman --noconfirm -U lib32-glfw-x11* && cd $OLD_PWD'
+RUN sudo -u builduser bash -c 'export OLD_PWD=$PWD && cd ~ && git clone https://aur.archlinux.org/lib32-glfw.git lib32-glfw && cd lib32-glfw && makepkg -s --noconfirm && sudo pacman --noconfirm -U lib32-glfw* && cd $OLD_PWD'
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Looks like the package name has been renamed with version 3.4.

See https://aur.archlinux.org/cgit/aur.git/commit/?h=lib32-glfw&id=d5add05705a845c2cc81d8c42c1ab13c116a054d

Confirmed to be working with https://github.com/jp7677/dxvk-nvapi/pull/288 (last commit switches to this PR) / https://github.com/jp7677/dxvk-nvapi/actions/runs/13884322508/job/38846967679?pr=288
  